### PR TITLE
Fix tstl configuration - create global export for gui & editor scripts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
         "luaPlugins": [
             {
                 "name": "@ts-defold/tstl-export-as-global",
-                "match": ".*\\.(?!editor_)script.ts$",
+                "match": ".*\\.(gui_|editor_)?script.ts$",
                 "globals": { 
                     "functions": [ "init", "on_input", "on_message", "on_reload", "update", "final"]
                 }


### PR DESCRIPTION
Previous configuration did not handled `gui` scripts correctly (which affected war battles template in particular).