### PR TITLE
Update tsconfig.json with newer features

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
         "lib": ["es2019"],
         "module": "commonjs",
         "esModuleInterop": true,
-        "experimentalDecorators": true,
         "moduleResolution": "node",
         "types": ["types", "language-extensions"],
         "typeRoots": [
@@ -30,7 +29,7 @@
     ],
     "tstl": {
         "luaTarget": "5.1",
-        "luaLibImport": "require",
+        "luaLibImport": "require-minimal",
         "sourceMapTraceback": true,
         "luaPlugins": [
             {


### PR DESCRIPTION
This PR proposes changes to the tsconfig to stay up to date with newer features.

## Additions
- `luaLibImport` is changed to the experimental value `require-minimal`. Introduced in [TSTL v1.13.0](https://github.com/TypeScriptToLua/TypeScriptToLua/blob/master/CHANGELOG.md#1130). This will result in slimmer output code.

## Removals
- `experimentalDecorators` is removed. Decorators are now stable in both [TypeScript](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#decorators) and [TSTL](https://github.com/TypeScriptToLua/TypeScriptToLua/blob/master/CHANGELOG.md#1160), so new projects don't need to opt into experimental support.